### PR TITLE
feat: add roommate profiles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,15 +3,23 @@
 @tailwind utilities;
 
 :root{
-  --radius: 16px;
-  --accent: #0a0a0a;
+  --radius: 12px;
+  --accent: #e0865f;
   --on-accent: #ffffff;
 }
 
 html, body, :root { height: 100%; }
-body { @apply bg-zinc-50 text-zinc-900 dark:bg-zinc-950 dark:text-zinc-50; }
+body {
+  background-color: #f6eade;
+  color: #5c4a43;
+  @apply dark:bg-zinc-950 dark:text-zinc-50;
+}
 .container { @apply max-w-7xl mx-auto px-6; }
-.card { @apply rounded-[var(--radius)] bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 shadow-sm; }
+.card {
+  @apply rounded-[var(--radius)] border dark:bg-zinc-900 dark:border-zinc-800 shadow-sm;
+  background-color: #fff7f2;
+  border-color: #e9dcd3;
+}
 .btn { @apply px-3 py-2 rounded-[calc(var(--radius)-8px)] text-sm; }
 .btn-accent { background: var(--accent); color: var(--on-accent); }
 .label { @apply text-sm text-zinc-600 dark:text-zinc-300; }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,20 +4,21 @@ import { Card, Chip, Tabs, Toggle, AccentButton, DesignProvider, DesignPanel } f
 import { addMinutes, startOfDay } from "date-fns";
 
 type Roommate = { id: string; name: string; color: string };
-const ROOMMATES: Roommate[] = [
-  { id: "yas", name: "Yasmeen", color: "bg-indigo-500" },
-  { id: "fra", name: "François", color: "bg-emerald-500" },
-  { id: "rag", name: "Raghda", color: "bg-rose-500" },
+const INITIAL_ROOMMATES: Roommate[] = [
+  { id: "pau", name: "Pau", color: "#f97316" },
+  { id: "yas", name: "Yasmeen", color: "#6366f1" },
+  { id: "sam", name: "Samantha", color: "#10b981" },
+  { id: "isa", name: "Isabelle", color: "#ef4444" },
 ];
 
 const today = new Date();
 const base = startOfDay(today);
 const mockEvents = () => ([
-  { title: "Class – PSYCH 2B03", start: addMinutes(base, 9*60), end: addMinutes(base, 10*60+20), owner: "yas" },
-  { title: "Gym", start: addMinutes(base, 7*60), end: addMinutes(base, 7*60+45), owner: "fra" },
-  { title: "Work block", start: addMinutes(base, 9*60), end: addMinutes(base, 12*60), owner: "fra" },
-  { title: "Clinic shift", start: addMinutes(base, 13*60), end: addMinutes(base, 17*60), owner: "rag" },
-  { title: "Study Group", start: addMinutes(base, 18*60), end: addMinutes(base, 19*60+30), owner: "yas" },
+  { title: "Class – PSYCH 2B03", start: addMinutes(base, 9 * 60), end: addMinutes(base, 10 * 60 + 20), owner: "yas" },
+  { title: "Gym", start: addMinutes(base, 7 * 60), end: addMinutes(base, 7 * 60 + 45), owner: "pau" },
+  { title: "Work block", start: addMinutes(base, 9 * 60), end: addMinutes(base, 12 * 60), owner: "sam" },
+  { title: "Clinic shift", start: addMinutes(base, 13 * 60), end: addMinutes(base, 17 * 60), owner: "isa" },
+  { title: "Study Group", start: addMinutes(base, 18 * 60), end: addMinutes(base, 19 * 60 + 30), owner: "yas" },
 ]);
 
 type Event = ReturnType<typeof mockEvents>[number];
@@ -47,26 +48,32 @@ function suggestCommonTimes({ events, people, windowStart, windowEnd, durationMi
   return suggestions.slice(0,10);
 }
 
-function Calendars(){
+function Calendars({ roommates }: { roommates: Roommate[] }){
   const [events] = React.useState<Event[]>(mockEvents());
-  const [visible, setVisible] = React.useState(Object.fromEntries(ROOMMATES.map(r=>[r.id,true])) as Record<string,boolean>);
+  const [visible, setVisible] = React.useState(Object.fromEntries(roommates.map(r=>[r.id,true])) as Record<string,boolean>);
   const [duration, setDuration] = React.useState(60);
-  const [participants, setParticipants] = React.useState(Object.fromEntries(ROOMMATES.map(r=>[r.id,true])) as Record<string,boolean>);
-  const dayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 8, 0);
-  const dayEnd = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 22, 0);
+  const [participants, setParticipants] = React.useState(Object.fromEntries(roommates.map(r=>[r.id,true])) as Record<string,boolean>);
+  const dayStart = React.useMemo(
+    () => new Date(today.getFullYear(), today.getMonth(), today.getDate(), 8, 0),
+    [today]
+  );
+  const dayEnd = React.useMemo(
+    () => new Date(today.getFullYear(), today.getMonth(), today.getDate(), 22, 0),
+    [today]
+  );
   const filtered = React.useMemo(()=>events.filter(e=>visible[e.owner]), [events,visible]);
   const suggestions = React.useMemo(()=>{
-    const selected = ROOMMATES.filter(r=>participants[r.id]).map(r=>r.id);
+    const selected = roommates.filter(r=>participants[r.id]).map(r=>r.id);
     if(selected.length<2) return [];
     return suggestCommonTimes({ events: filtered, people: selected, windowStart: dayStart, windowEnd: dayEnd, durationMin: Number(duration) });
-  }, [filtered, participants, duration]);
+  }, [filtered, participants, duration, dayStart, dayEnd, roommates]);
 
   return (
     <div className="grid grid-cols-1 xl:grid-cols-5 gap-4">
       <Card className="xl:col-span-3">
         <div className="flex items-center justify-between mb-3">
           <h3 className="font-semibold">Today • {today.toLocaleDateString()}</h3>
-          <div className="flex gap-3">{ROOMMATES.map(r=>(
+          <div className="flex gap-3">{roommates.map(r=>(
             <Toggle key={r.id} label={r.name} checked={visible[r.id]} onChange={(v)=>setVisible(s=>({ ...s, [r.id]: v }))} />
           ))}</div>
         </div>
@@ -81,12 +88,21 @@ function Calendars(){
             );
           })}
           {filtered.map((ev,idx)=>{
-            const total=(22-8)*60; const startMin=(ev.start.getHours()*60+ev.start.getMinutes())-8*60;
-            const top=(startMin/total)*15*48; const height=((ev.end.getTime()-ev.start.getTime())/60000)/total*15*48;
-            const owner = ROOMMATES.find(r=>r.id===ev.owner);
+            const total=(22-8)*60;
+            const start=Math.max(ev.start.getTime(), dayStart.getTime());
+            const end=Math.min(ev.end.getTime(), dayEnd.getTime());
+            if(end <= dayStart.getTime() || start >= dayEnd.getTime()) return null;
+            const startMin=(start - dayStart.getTime())/60000;
+            const duration=(end - start)/60000;
+            const top=(startMin/total)*15*48;
+            const height=(duration/total)*15*48;
+            const owner = roommates.find(r=>r.id===ev.owner);
             return (
               <div key={idx} className="absolute left-20 right-4" style={{ top, height }}>
-                <div className={`h-full rounded-[calc(var(--radius)-6px)] shadow text-white text-xs p-2 ${owner?.color || 'bg-zinc-500'}`}>
+                <div
+                  className="h-full rounded-[calc(var(--radius)-6px)] shadow text-white text-xs p-2"
+                  style={{ background: owner?.color || '#71717a' }}
+                >
                   <div className="font-semibold text-sm">{ev.title}</div>
                   <div>{ev.start.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'})} – {ev.end.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'})}</div>
                   <div className="opacity-80 mt-1">{owner?.name}</div>
@@ -98,7 +114,7 @@ function Calendars(){
       </Card>
       <Card className="xl:col-span-2">
         <h3 className="font-semibold mb-3">Suggest a time</h3>
-        <div className="flex flex-wrap gap-3 mb-3">{ROOMMATES.map(r=>(
+        <div className="flex flex-wrap gap-3 mb-3">{roommates.map(r=>(
           <Toggle key={r.id} label={r.name} checked={participants[r.id]} onChange={(v)=>setParticipants(s=>({ ...s, [r.id]: v }))} />
         ))}</div>
         <div className="flex items-center gap-3 mb-3">
@@ -124,12 +140,59 @@ function Calendars(){
   );
 }
 
-function Chores(){
-  const [chores, setChores] = React.useState([
-    { id:"c1", room:"Kitchen", task:"Dishes", recurrence:"Daily", assignedTo:"yas", nextDue: new Date(today.getFullYear(), today.getMonth(), today.getDate(), 20, 0) },
-    { id:"c2", room:"Bathroom", task:"Clean sink & mirror", recurrence:"Weekly (Sat)", assignedTo:"rag", nextDue: new Date(today.getFullYear(), today.getMonth(), today.getDate()+2, 11, 0) },
-    { id:"c3", room:"Living Room", task:"Vacuum", recurrence:"Weekly (Sun)", assignedTo:"fra", nextDue: new Date(today.getFullYear(), today.getMonth(), today.getDate()+3, 15, 0) },
-  ] as any[]);
+function Chores({ roommates }: { roommates: Roommate[] }){
+  const [chores, setChores] = React.useState(() => {
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem("chores");
+      if (stored) {
+        try {
+          return (JSON.parse(stored) as any[]).map(c => ({
+            ...c,
+            nextDue: new Date(c.nextDue),
+          }));
+        } catch {}
+      }
+    }
+    return [
+      {
+        id: "c1",
+        room: "Kitchen",
+        task: "Dishes",
+        recurrence: "Daily",
+        assignedTo: "pau",
+        nextDue: new Date(today.getFullYear(), today.getMonth(), today.getDate(), 20, 0),
+      },
+      {
+        id: "c2",
+        room: "Bathroom",
+        task: "Clean sink & mirror",
+        recurrence: "Weekly (Sat)",
+        assignedTo: "yas",
+        nextDue: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 2, 11, 0),
+      },
+      {
+        id: "c3",
+        room: "Living Room",
+        task: "Vacuum",
+        recurrence: "Weekly (Sun)",
+        assignedTo: "sam",
+        nextDue: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 3, 15, 0),
+      },
+      {
+        id: "c4",
+        room: "Garage",
+        task: "Take out recycling",
+        recurrence: "Weekly (Mon)",
+        assignedTo: "isa",
+        nextDue: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 4, 9, 0),
+      },
+    ] as any[];
+  });
+  React.useEffect(() => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem("chores", JSON.stringify(chores));
+    }
+  }, [chores]);
   const [filterRoom, setFilterRoom] = React.useState("All");
   const rooms = React.useMemo(()=>["All", ...Array.from(new Set(chores.map(c=>c.room)))], [chores]);
   const filtered = React.useMemo(()=> chores.filter(c => filterRoom==="All" || c.room===filterRoom), [chores, filterRoom]);
@@ -140,7 +203,7 @@ function Chores(){
     const room = (form.get("room")?.toString() || "General");
     const task = (form.get("task")?.toString() || "");
     const recurrence = (form.get("rec")?.toString() || "Weekly");
-    const assignedTo = (form.get("who")?.toString() || ROOMMATES[0].id);
+    const assignedTo = (form.get("who")?.toString() || roommates[0]?.id || "");
     if(!task) return;
     setChores(cs => cs.concat({ id: crypto.randomUUID(), room, task, recurrence, assignedTo, nextDue: new Date() }));
     e.currentTarget.reset();
@@ -159,18 +222,23 @@ function Chores(){
           </div>
         </div>
         <div className="divide-y divide-zinc-200 dark:divide-zinc-800">
-          {filtered.map(c => (
-            <div key={c.id} className="py-3 flex items-center justify-between">
-              <div>
-                <div className="font-medium">{c.task} <span className="text-xs text-zinc-500">• {c.room}</span></div>
-                <div className="text-xs text-zinc-500">{c.recurrence} • Next due {new Date(c.nextDue).toLocaleString()}</div>
+          {filtered.map(c => {
+            const assignee = roommates.find(r=>r.id===c.assignedTo);
+            return (
+              <div key={c.id} className="py-3 flex items-center justify-between">
+                <div>
+                  <div className="font-medium">{c.task} <span className="text-xs text-zinc-500">• {c.room}</span></div>
+                  <div className="text-xs text-zinc-500">{c.recurrence} • Next due {new Date(c.nextDue).toLocaleString()}</div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <Chip className="text-white" style={{ background: assignee?.color, borderColor: assignee?.color }}>
+                    {assignee?.name || c.assignedTo}
+                  </Chip>
+                  <AccentButton onClick={()=>markDone(c.id)}>Done</AccentButton>
+                </div>
               </div>
-              <div className="flex items-center gap-3">
-                <Chip>{ROOMMATES.find(r=>r.id===c.assignedTo)?.name || c.assignedTo}</Chip>
-                <AccentButton onClick={()=>markDone(c.id)}>Done</AccentButton>
-              </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </Card>
       <Card>
@@ -193,7 +261,7 @@ function Chores(){
           <div>
             <label className="label">Assign to</label>
             <select name="who" className="input mt-1">
-              {ROOMMATES.map(r=> <option key={r.id} value={r.id}>{r.name}</option>)}
+              {roommates.map(r=> <option key={r.id} value={r.id}>{r.name}</option>)}
             </select>
           </div>
           <AccentButton className="w-full">Add chore</AccentButton>
@@ -204,34 +272,81 @@ function Chores(){
   );
 }
 
-function CostsGroceries(){
-  const [expenses, setExpenses] = React.useState([
-    { id:"e1", date: new Date(), payer:"fra", description:"Paper towels", amount: 8.99, split:["yas","rag","fra"] },
-    { id:"e2", date: new Date(), payer:"yas", description:"Dish soap", amount: 5.49, split:["yas","rag","fra"] },
-  ] as any[]);
-  const [groceries, setGroceries] = React.useState([
-    { id:"g1", name:"Milk 2L", lastPrice: 4.69, need:true },
-    { id:"g2", name:"Eggs (12)", lastPrice: 3.99, need:false },
-    { id:"g3", name:"Rice 5kg", lastPrice: 12.49, need:true },
-  ] as any[]);
+function CostsGroceries({ roommates }: { roommates: Roommate[] }){
+  const [expenses, setExpenses] = React.useState(() => {
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem("expenses");
+      if (stored) {
+        try {
+          return (JSON.parse(stored) as any[]).map(e => ({
+            ...e,
+            date: new Date(e.date),
+          }));
+        } catch {}
+      }
+    }
+    return [
+      {
+        id: "e1",
+        date: new Date(),
+        payer: "pau",
+        description: "Paper towels",
+        amount: 8.99,
+        split: ["pau", "yas", "sam", "isa"],
+      },
+      {
+        id: "e2",
+        date: new Date(),
+        payer: "yas",
+        description: "Dish soap",
+        amount: 5.49,
+        split: ["pau", "yas", "sam", "isa"],
+      },
+    ] as any[];
+  });
+  React.useEffect(() => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem("expenses", JSON.stringify(expenses));
+    }
+  }, [expenses]);
+  const [groceries, setGroceries] = React.useState(() => {
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem("groceries");
+      if (stored) {
+        try {
+          return JSON.parse(stored) as any[];
+        } catch {}
+      }
+    }
+    return [
+      { id:"g1", name:"Milk 2L", lastPrice: 4.69, need:true },
+      { id:"g2", name:"Eggs (12)", lastPrice: 3.99, need:false },
+      { id:"g3", name:"Rice 5kg", lastPrice: 12.49, need:true },
+    ] as any[];
+  });
+  React.useEffect(() => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem("groceries", JSON.stringify(groceries));
+    }
+  }, [groceries]);
 
   const balances = React.useMemo(()=>{
-    const map = new Map<string, number>(ROOMMATES.map(r=>[r.id,0]));
+    const map = new Map<string, number>(roommates.map(r=>[r.id,0]));
     for(const e of expenses){
       const share = e.amount / e.split.length;
       for(const p of e.split){ map.set(p, (map.get(p) || 0) - share); }
       map.set(e.payer, (map.get(e.payer) || 0) + e.amount);
     }
     return map;
-  }, [expenses]);
+  }, [expenses, roommates]);
 
   function addExpense(e: React.FormEvent<HTMLFormElement>){
     e.preventDefault();
     const form = new FormData(e.currentTarget);
     const description = form.get("desc")?.toString() || "";
     const amount = parseFloat(form.get("amt")?.toString() || "0");
-    const payer = form.get("payer")?.toString() || ROOMMATES[0].id;
-    const split = ROOMMATES.map(r => form.get(`split_${r.id}`) ? r.id : null).filter(Boolean) as string[];
+    const payer = form.get("payer")?.toString() || roommates[0]?.id || "";
+    const split = roommates.map(r => form.get(`split_${r.id}`) ? r.id : null).filter(Boolean) as string[];
     if(!description || !amount || split.length===0) return;
     setExpenses(es => es.concat({ id: crypto.randomUUID(), date: new Date(), payer, description, amount, split }));
     setGroceries(gs => gs.map(g => g.name.toLowerCase().includes(description.toLowerCase()) ? { ...g, lastPrice: amount } : g));
@@ -261,12 +376,12 @@ function CostsGroceries(){
               <div className="flex items-center gap-2">
                 <span className="text-sm">Payer:</span>
                 <select name="payer" className="px-2 py-1 rounded-lg border border-zinc-300 dark:border-zinc-700">
-                  {ROOMMATES.map(r=> <option key={r.id} value={r.id}>{r.name}</option>)}
+                  {roommates.map(r=> <option key={r.id} value={r.id}>{r.name}</option>)}
                 </select>
               </div>
               <div className="text-sm">Split with:</div>
               <div className="flex flex-wrap gap-3">
-                {ROOMMATES.map(r=> (
+                {roommates.map(r=> (
                   <label key={r.id} className="flex items-center gap-2 text-sm">
                     <input type="checkbox" name={`split_${r.id}`} defaultChecked /> {r.name}
                   </label>
@@ -278,12 +393,12 @@ function CostsGroceries(){
           <div>
             <div className="text-sm font-medium mb-2">Balances</div>
             <div className="space-y-2">
-              {ROOMMATES.map(r=>{
+              {roommates.map(r=>{
                 const val = balances.get(r.id) || 0;
                 const isPos = val>=0;
                 return (
                   <div key={r.id} className="flex items-center justify-between p-2 rounded-[calc(var(--radius)-6px)] border border-zinc-200 dark:border-zinc-800">
-                    <div className="font-medium">{r.name}</div>
+                    <Chip className="text-white" style={{ background: r.color, borderColor: r.color }}>{r.name}</Chip>
                     <div className={isPos? 'text-emerald-600' : 'text-rose-600'}>{isPos? '+$' : '-$'}{Math.abs(val).toFixed(2)}</div>
                   </div>
                 );
@@ -321,8 +436,58 @@ function CostsGroceries(){
   );
 }
 
+function Profiles({ roommates, setRoommates }:{ roommates: Roommate[]; setRoommates: React.Dispatch<React.SetStateAction<Roommate[]>> }){
+  const [draft, setDraft] = React.useState<Roommate[]>(roommates);
+  React.useEffect(() => setDraft(roommates), [roommates]);
+  const update = (id: string, data: Partial<Roommate>) =>
+    setDraft(rs => rs.map(r => r.id===id ? { ...r, ...data } : r));
+  return (
+    <Card>
+      <h3 className="font-semibold mb-3">Roommate profiles</h3>
+      <div className="space-y-2">
+        {draft.map(r => (
+          <div key={r.id} className="flex items-center gap-2">
+            <input
+              className="input flex-1"
+              value={r.name}
+              onChange={e=>update(r.id,{ name:e.target.value })}
+            />
+            <input
+              type="color"
+              className="w-10 h-10 rounded"
+              value={r.color}
+              onChange={e=>update(r.id,{ color:e.target.value })}
+            />
+          </div>
+        ))}
+      </div>
+      <AccentButton
+        className="mt-4"
+        onClick={() => {
+          setRoommates(draft);
+          if (typeof window !== "undefined") {
+            localStorage.setItem("roommates", JSON.stringify(draft));
+          }
+        }}
+      >
+        Save
+      </AccentButton>
+    </Card>
+  );
+}
+
 export default function HomePage(){
-  const [tab, setTab] = React.useState<"Calendars"|"Chores"|"Costs & Groceries">("Calendars");
+  const [roommates, setRoommates] = React.useState<Roommate[]>(INITIAL_ROOMMATES);
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = localStorage.getItem("roommates");
+    if (stored) {
+      try {
+        setRoommates(JSON.parse(stored));
+      } catch {}
+    }
+  }, []);
+  const [tab, setTab] = React.useState<"Calendars"|"Chores"|"Costs & Groceries"|"Profiles">("Calendars");
   return (
     <DesignProvider>
       <div className="container py-6">
@@ -336,10 +501,11 @@ export default function HomePage(){
             <Chip>Theme‑able</Chip>
           </div>
         </header>
-        <Tabs tabs={["Calendars","Chores","Costs & Groceries"]} current={tab} onChange={(t)=>setTab(t as any)} />
-        {tab==="Calendars" && <Calendars/>}
-        {tab==="Chores" && <Chores/>}
-        {tab==="Costs & Groceries" && <CostsGroceries/>}
+        <Tabs tabs={["Calendars","Chores","Costs & Groceries","Profiles"]} current={tab} onChange={(t)=>setTab(t as any)} />
+        {tab==="Calendars" && <Calendars roommates={roommates}/>}
+        {tab==="Chores" && <Chores roommates={roommates}/>}
+        {tab==="Costs & Groceries" && <CostsGroceries roommates={roommates}/>}
+        {tab==="Profiles" && <Profiles roommates={roommates} setRoommates={setRoommates}/>}
         <footer className="mt-10 text-xs text-zinc-500">
           Next: connect Google/Microsoft calendars via OAuth, add proposals & notifications, persist data.
         </footer>

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -10,7 +10,7 @@ export const useDesign = () => {
 };
 
 export function DesignProvider({ children }: { children: React.ReactNode }){
-  const [design, setDesign] = useState({ compact:false, radius:16, accent:"#0a0a0a", onAccent:"#ffffff", setDesign: (_: any)=>{} } as any);
+  const [design, setDesign] = useState({ compact:false, radius:12, accent:"#e0865f", onAccent:"#ffffff", setDesign: (_: any)=>{} } as any);
   (design as any).setDesign = setDesign;
   return (
     <DesignContext.Provider value={design as any}>
@@ -24,15 +24,23 @@ export function Card(props: React.HTMLAttributes<HTMLDivElement>){
   return <div className={`card p-4 ${className}`} {...rest} />;
 }
 
-export function Chip({ children }: { children: React.ReactNode }){
-  return <span className="px-2 py-0.5 rounded-full text-xs bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700">{children}</span>;
+export function Chip(props: React.HTMLAttributes<HTMLSpanElement>){
+  const { className="", children, ...rest } = props;
+  return (
+    <span
+      className={`px-2 py-0.5 rounded-full text-xs bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 ${className}`}
+      {...rest}
+    >
+      {children}
+    </span>
+  );
 }
 
 export function Toggle({ checked, onChange, label }:{ checked:boolean; onChange:(v:boolean)=>void; label:string; }){
   return (
     <label className="flex items-center gap-2 select-none cursor-pointer">
       <input type="checkbox" className="sr-only" checked={checked} onChange={e=>onChange(e.target.checked)} />
-      <span className={`inline-block w-10 h-6 rounded-full transition ${checked ? 'bg-emerald-500' : 'bg-zinc-300 dark:bg-zinc-700'}`}>
+      <span className={`inline-block w-10 h-6 rounded-full transition ${checked ? 'bg-[var(--accent)]' : 'bg-zinc-300 dark:bg-zinc-700'}`}>
         <span className={`block h-5 w-5 bg-white rounded-full shadow transform transition ${checked ? 'translate-x-5' : 'translate-x-0.5'} mt-0.5`} />
       </span>
       <span className="text-sm text-zinc-700 dark:text-zinc-300">{label}</span>


### PR DESCRIPTION
## Summary
- adopt pastel accent and background colors
- adjust default design and toggle to use accent
- clamp calendar events to daylight hours
- seed editable roommate profiles and propagate them through calendars, chores, and costs
- color-code roommate chips and events so profile edits reflect across the app
- add save button so profile edits persist only when saved
- persist roommate profile changes to localStorage and load saved profiles on start
- persist chores, expenses, and grocery items to localStorage so additions save automatically

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c05d625bc4832296a068c412b28ce6