### PR TITLE
feat: add roommate profiles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,15 +3,23 @@
 @tailwind utilities;
 
 :root{
-  --radius: 16px;
-  --accent: #0a0a0a;
+  --radius: 12px;
+  --accent: #e0865f;
   --on-accent: #ffffff;
 }
 
 html, body, :root { height: 100%; }
-body { @apply bg-zinc-50 text-zinc-900 dark:bg-zinc-950 dark:text-zinc-50; }
+body {
+  background-color: #f6eade;
+  color: #5c4a43;
+  @apply dark:bg-zinc-950 dark:text-zinc-50;
+}
 .container { @apply max-w-7xl mx-auto px-6; }
-.card { @apply rounded-[var(--radius)] bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 shadow-sm; }
+.card {
+  @apply rounded-[var(--radius)] border dark:bg-zinc-900 dark:border-zinc-800 shadow-sm;
+  background-color: #fff7f2;
+  border-color: #e9dcd3;
+}
 .btn { @apply px-3 py-2 rounded-[calc(var(--radius)-8px)] text-sm; }
 .btn-accent { background: var(--accent); color: var(--on-accent); }
 .label { @apply text-sm text-zinc-600 dark:text-zinc-300; }

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -10,7 +10,7 @@ export const useDesign = () => {
 };
 
 export function DesignProvider({ children }: { children: React.ReactNode }){
-  const [design, setDesign] = useState({ compact:false, radius:16, accent:"#0a0a0a", onAccent:"#ffffff", setDesign: (_: any)=>{} } as any);
+  const [design, setDesign] = useState({ compact:false, radius:12, accent:"#e0865f", onAccent:"#ffffff", setDesign: (_: any)=>{} } as any);
   (design as any).setDesign = setDesign;
   return (
     <DesignContext.Provider value={design as any}>
@@ -24,15 +24,23 @@ export function Card(props: React.HTMLAttributes<HTMLDivElement>){
   return <div className={`card p-4 ${className}`} {...rest} />;
 }
 
-export function Chip({ children }: { children: React.ReactNode }){
-  return <span className="px-2 py-0.5 rounded-full text-xs bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700">{children}</span>;
+export function Chip(props: React.HTMLAttributes<HTMLSpanElement>){
+  const { className="", children, ...rest } = props;
+  return (
+    <span
+      className={`px-2 py-0.5 rounded-full text-xs bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 ${className}`}
+      {...rest}
+    >
+      {children}
+    </span>
+  );
 }
 
 export function Toggle({ checked, onChange, label }:{ checked:boolean; onChange:(v:boolean)=>void; label:string; }){
   return (
     <label className="flex items-center gap-2 select-none cursor-pointer">
       <input type="checkbox" className="sr-only" checked={checked} onChange={e=>onChange(e.target.checked)} />
-      <span className={`inline-block w-10 h-6 rounded-full transition ${checked ? 'bg-emerald-500' : 'bg-zinc-300 dark:bg-zinc-700'}`}>
+      <span className={`inline-block w-10 h-6 rounded-full transition ${checked ? 'bg-[var(--accent)]' : 'bg-zinc-300 dark:bg-zinc-700'}`}>
         <span className={`block h-5 w-5 bg-white rounded-full shadow transform transition ${checked ? 'translate-x-5' : 'translate-x-0.5'} mt-0.5`} />
       </span>
       <span className="text-sm text-zinc-700 dark:text-zinc-300">{label}</span>


### PR DESCRIPTION
## Summary
- adopt pastel accent and background colors
- adjust default design and toggle to use accent
- clamp calendar events to daylight hours
- seed editable roommate profiles and propagate them through calendars, chores, and costs
- color-code roommate chips and events so profile edits reflect across the app
- add save button so profile edits persist only when saved
- persist roommate profile changes to localStorage and load saved profiles on start
- persist chores, expenses, and grocery items to localStorage so additions save automatically
- remove unnecessary memo dependencies in calendars to silence lint warnings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c05d625bc4832296a068c412b28ce6